### PR TITLE
Don't discard data in TCP segments with the FIN flag set

### DIFF
--- a/lib/pcap_tools/packet_processors/tcp.rb
+++ b/lib/pcap_tools/packet_processors/tcp.rb
@@ -22,24 +22,21 @@ module PcapTools
             :data => [],
             :tcp_lost_segment => false,
           }
-        elsif packet[:tcp_flags][:fin] || packet[:tcp_flags][:rst]
-          if @streams[stream_index]
+        elsif @streams[stream_index]
+          tcp_flags = packet[:tcp_flags]
+          packet[:type] = (packet[:from] == @streams[stream_index][:first][:from] && packet[:from_port] == @streams[stream_index][:first][:from_port]) ? :out : :in
+          packet.delete :tcp_flags
+          @streams[stream_index][:data] << packet if packet[:size] > 0
+          if packet[:tcp_lost_segment]
+            @streams.delete stream_index
+            $stderr.puts "Ignoring tcp stream #{stream_index}, tcp segments are missing"
+          elsif tcp_flags[:fin] || tcp_flags[:rst]
             current = {:index => stream_index, :data => @streams[stream_index][:data]}
             @stream_processors.each do |p|
               current = p.process_stream current
               break unless current
             end
             @streams.delete stream_index
-          end
-        else
-          if @streams[stream_index]
-            packet[:type] = (packet[:from] == @streams[stream_index][:first][:from] && packet[:from_port] == @streams[stream_index][:first][:from_port]) ? :out : :in
-            packet.delete :tcp_flags
-            @streams[stream_index][:data] << packet if packet[:size] > 0
-            if packet[:tcp_lost_segment]
-              @streams.delete stream_index
-              $stderr.puts "Ignoring tcp stream #{stream_index}, tcp segments are missing"
-            end
           end
         end
       end


### PR DESCRIPTION
A TCP segment that has the FIN flag set may also contain data. The following segment contains 848 octets of data and has the FIN flag set:

```
19:03:37.804959 IP 192.168.180.100.7899 > 192.168.180.101.53209: Flags [FP.], seq 27473:28321, ack 2225, win 272, options [nop,nop,TS val 138775536 ecr 138708319], length 848
```

[RFC 793](http://tools.ietf.org/html/rfc793#page-26) states that:

> For sequence number purposes, ... the FIN is considered to occur after the last actual data octet in a segment in which it occurs.

When a segment with a FIN flag is detected, `PcapTools::TcpProcessor` currently ends stream reassembly without processing data from that segment. This causes the reassembled stream to be truncated when a segment containing data with a FIN flag is encountered.

This pull request changes the order of processing such that the data is appended to the stream prior to checking for and processing the FIN and RST flags.
